### PR TITLE
Add Pi Camera support

### DIFF
--- a/inv/urls.py
+++ b/inv/urls.py
@@ -23,4 +23,6 @@ urlpatterns = [
         path('reports/full/', views.report_full, name='report_full'),
         path('keyword/', views.keywords, name='keywords'),
         path('keyword/<str:kw_slug>/', views.keywords, name='keyword'),
+        path('capture/<str:fileName>/', views.cameraCapture, name='piCapture'),
+        path('capture/<str:fileName>/<str:fname>/', views.cameraCapture, name='pi_success'),
         ]

--- a/inv/views.py
+++ b/inv/views.py
@@ -1,9 +1,12 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.http import HttpResponse
 from .models import Warehouse, Boxes, Items, Staff, Items_in_boxes, Keywords, Keywords_in_items, Inventory
 from django.db.models import Count, Sum, Q, F, DecimalField, FloatField, IntegerField, ExpressionWrapper
 from django.db.models.functions import Lower
 from decimal import Decimal
+from picamera import PiCamera
+from time import sleep
+from datetime import datetime
 
 def index(request):
     item_count = Items.objects.all().annotate(Count("item_id"))
@@ -119,3 +122,18 @@ def keywords(request, kw_slug=None):
     else:
         kw = Keywords.objects.all()
         return render(request, 'inv/keywords.html', {'kw' : kw})
+
+def cameraCapture(request, fileName=None, fname=None):
+    if fname:
+        return render(request, 'inv/photo.html', {'fileName' : fileName, 'fname' : fname})
+    elif fileName:
+        date_time = datetime.now()
+        fname = fileName + '_' + str(datetime.now()) + '.jpg'
+        fname = str(fname)
+        camera = PiCamera()
+        camera.start_preview()
+        sleep(5)
+        camera.capture('/home/pi/Apps/mobiliaire/static/inv/img/new/%s' % fname)
+        camera.stop_preview()
+        camera.close()
+        return redirect('/capture/%s/%s/' % (fileName, fname))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==3.1.1
 django-csvimport==2.16
+picamera==1.13

--- a/templates/inv/box.html
+++ b/templates/inv/box.html
@@ -3,18 +3,30 @@
 
 {% block content %}
 {% load static %}
-  
-  <h1>Box: {{ box.box_name }}</h1>
-  <p class="lead">This box is part of the {{ box.warehouse }} warehouse. It
-  contains {{ items.item_totals.icount }} items with a total value of ${{ items.item_totals.val|floatformat:2 }}.</p>
+<div class="media">
+  <img class="mr-3"
+  src="{% static 'inv/img/'|add:box.box_img %}"
+  alt="Photo of box {{ box.box_id }}"
+  caption="Box {{ box.box_id }} | {{ box.box_name }}"
+  height="300px"/>
+  <div class="media-body">
+<h1 class="m1-0">Box: {{ box.box_name }}</h1>
+<p class="lead">This box is part of the {{ box.warehouse }} warehouse. It
+contains {{ items.item_totals.icount }} items with a total value of ${{ items.item_totals.val|floatformat:2 }}.</p>
+{% with boxid=box.box_id|slugify  %}
+<p><a href="{% url 'piCapture' 'box_'|add:boxid %}" target="_blank">Try submitting a new photo of this box via the Pi Camera.</a></p>
+{% endwith %}
+</div>
+</div>
+
   <div class="row mb-3">
     {% for i in items %}
         <div class="col-md-4 themed-grid-col">
-    
+
 
       <div class="card mb-4 border-dark">
         {% if i.item_id.item_img|length > 0 %}
-        <img class="card-img-top" src="{% static 'inv/img/'|add:i.item_img %}" 
+        <img class="card-img-top" src="{% static 'inv/img/'|add:i.item_img %}"
                                   alt="Box">
         {% else %}
         <p>This item does not have an image. You can add one by taking a photo
@@ -48,5 +60,5 @@
         {% endfor %}
   </div>
 
-  
+
 {% endblock %}

--- a/templates/inv/item.html
+++ b/templates/inv/item.html
@@ -2,7 +2,7 @@
 
 
 {% block content %}
-{% load static %} 
+{% load static %}
  <!-- Main jumbotron for a primary marketing message or call to action -->
   <div class="jumbotron">
     <div class="container">
@@ -17,6 +17,10 @@
       to contribute, please snap a photo and email it to the site contact with
       a subject line of "Property database photo for item {{ item.item_id }}"
       so we can add it (and so we know which database entry to add it to!).
+      </p>
+      {% with itemid=item.item_id|slugify  %}
+      <p><a href="{% url 'piCapture' 'item_'|add:itemid %}" target="_blank">Try submitting a new photo via the Pi Camera.</a></p>
+      {% endwith %}
       {% endif %}
     </div>
   </div>
@@ -36,12 +40,12 @@
         {% else %}
         Consumable: No<br/>
         {% endif %}
-        </p> 
+        </p>
       </div>
     </div>
   </div>
   <hr>
 </div><!-- /container -->
 
-  
+
 {% endblock %}

--- a/templates/inv/photo.html
+++ b/templates/inv/photo.html
@@ -9,11 +9,14 @@
       {% if fileName %}
       <h1 class="display-3">Photo Added for {{ fileName }}</h1>
       <p>File name is {{ fname }}</p>
+      <p>The photo will not be automatically added to the item, box, or warehouse it is of.
+        An administrator will review all of the submitted photos and update all items, boxes,
+        and warehouses with successful captures after the event has concluded.</p>
       <img src="{% static 'inv/img/new/'|add:fname %}" alt="Photograph
         of item"/>
       <p>Please verify that the image appears above. If it does not, please notify
         the local administrator. </p>
-        <p>You may close this window or tab to return to the page you started from.</p>
+        <p>You may close this window/tab to return to the page you started from.</p>
       {% else %}
       <p class="warning">Something went wrong. If you received this error via clicking a link, please report this to the local
         administrator, including the following information, if anything is displayed:</p>

--- a/templates/inv/photo.html
+++ b/templates/inv/photo.html
@@ -1,0 +1,34 @@
+{% extends 'inv/base.html' %}
+
+
+{% block content %}
+{% load static %}
+ <!-- Main jumbotron for a primary marketing message or call to action -->
+  <div class="jumbotron">
+    <div class="container">
+      {% if fileName %}
+      <h1 class="display-3">Photo Added for {{ fileName }}</h1>
+      <p>File name is {{ fname }}</p>
+      <img src="{% static 'inv/img/new/'|add:fname %}" alt="Photograph
+        of item"/>
+      <p>Please verify that the image appears above. If it does not, please notify
+        the local administrator. </p>
+        <p>You may close this window or tab to return to the page you started from.</p>
+      {% else %}
+      <p class="warning">Something went wrong. If you received this error via clicking a link, please report this to the local
+        administrator, including the following information, if anything is displayed:</p>
+        <ul>
+          <li>fileName: {{ fileName }}</li>
+          <li>fname: {{ fname }}</li>
+          </ul>
+        <p>Attempting to visit this page directly may result in an error. Please only visit this page via link from the
+          Warehouse, Box, or Item page.</p>
+      {% endif %}
+    </div>
+  </div>
+
+  <hr>
+
+
+
+{% endblock %}

--- a/templates/inv/warehouse.html
+++ b/templates/inv/warehouse.html
@@ -2,14 +2,26 @@
 
 
 {% block content %}
-{% load static %} 
-  <!-- Main jumbotron for a primary marketing message or call to action -->
-  <h1>Warehouse: {{ wh.warehouse_name }}</h1>
-  <p class="lead">This warehouse is located at {{ wh.warehouse_loc }}.</p>
+{% load static %}
+<div class="media">
+<img class="mr-3"
+src="{% static 'inv/img/'|add:wh.warehouse_img %}"
+alt="Photo of warehouse {{ wh.warehouse_id }}"
+caption="Warehouse {{ wh.warehouse_id }} | {{ wh.warehouse_name }}"
+height="300px"/>
+<div class="media-body">
+<h1 class="m1-0">Warehouse: {{ wh.warehouse_name }}</h1>
+<p class="lead">This warehouse is located at {{ wh.warehouse_loc }}.</p>
+{% with whid=wh.warehouse_id|slugify  %}
+<p><a href="{% url 'piCapture' 'wh_'|add:whid %}" target="_blank">Try submitting a new photo of this warehouse via the Pi Camera.</a></p>
+{% endwith %}
+</div>
+</div>
+
   <div class="row mb-3">
     {% for b in boxes %}
         <div class="col-md-4 themed-grid-col">
-    
+
 
       <div class="card mb-4 border-dark">
         <img class="card-img-top" src="{% static 'inv/img/'|add:b.box_img %}" alt="Box Designator">
@@ -27,5 +39,5 @@
         {% endfor %}
   </div>
 
-  
+
 {% endblock %}


### PR DESCRIPTION
This pull incorporates the following:

Changes to views.py, urls.py, item.html, and creation of photo.html are to add pi camera support
Changes to warehouse.html and box.html are to incorporate a change made concurrently to the upstream; to wit: displaying a warehouse's or box's photo on the individual box/warehouse detail pages.
Changes to warehouse.html and box.html also add the "Take a photo" link just like item.html does.